### PR TITLE
Maj projections Wallis, Polynésie, Nouvelle Calédonie

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ npm install @etalab/project-legal @babel/runtime-corejs2
 | Réunion | RGR92 / UTM zone 40S |
 | Mayotte | RGM04 / UTM zone 38S |
 | Saint-Pierre-et-Miquelon | RGSPM06 / UTM zone 21N |
+| Nouvelle Calédonie | RGNC91-93 / Lambert New Caledonia |
+| Polynésie Française | RGPF / UTM zone 5S 6S 7S 8S |
+| Wallis et Futuna | MOP78 / UTM zone 1S |
 
 ## Licence
 

--- a/projections.json
+++ b/projections.json
@@ -46,5 +46,54 @@
     "bounds": [-57.1, 43.41, -55.9, 47.37],
     "proj4": "+proj=utm +zone=21 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs",
     "precision": 2
+  },
+  {
+    "name": "RGNC91-93 / Lambert New Caledonia",
+    "description": "Nouvelle Calédonie",
+    "epsg": 3163,
+    "bounds": [163.55, -22.75, 168.2, -19.54],
+    "proj4": "+proj=lcc +lat_1=-20.66666666666667 +lat_2=-22.33333333333333 +lat_0=-21.5 +lon_0=166 +x_0=400000 +y_0=300000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs",
+    "precision": 2
+  },
+  {
+    "name": "RGPF / UTM zone 5S",
+    "description": "Polynésie Française - UTM zone 5S",
+    "epsg": 3296,
+    "bounds": [-155.00, -24.00, -150.00, -9.00],
+    "proj4": "+proj=utm +zone=5 +south +ellps=GRS80 +units=m +no_defs",
+    "precision": 2
+  },
+  {
+    "name": "RGPF UTM zone 6S",
+    "description": "Polynésie Française - UTM zone 6S",
+    "epsg": 3297,
+    "bounds": [-150.00, -29.00, -144.00, -13.00],
+    "proj4": "+proj=utm +zone=6 +south +ellps=GRS80 +units=m +no_defs",
+    "precision": 2
+  },
+  {
+    "name": "RGPF UTM zone 7S",
+    "description": "Polynésie Française - UTM zone 7S",
+    "epsg": 3298,
+    "bounds": [-144.00, -29.00, -138.00, -7.00],
+    "proj4": "+proj=utm +zone=7 +south +ellps=GRS80 +units=m +no_defs",
+    "precision": 2
+  },
+  {
+    "name": "RGPF UTM zone 8S",
+    "description": "Polynésie Française - UTM zone 8S",
+    "epsg": 3299,
+    "bounds": [-138.00, -25.00, -132.00, -18.00],
+    "proj4": "+proj=utm +zone=8 +south +ellps=GRS80 +units=m +no_defs",
+    "precision": 2
+  },
+  {
+    "name": "MOP78 / UTM zone 1S",
+    "description": "Wallis and Futuna - Wallis - UTM zone 1S",
+    "epsg": 2988,
+    "bounds": [-177.00, -14.00, -176.00, -13.00],
+    "proj4": "+proj=utm +zone=1 +south +ellps=intl +units=m +no_defs",
+    "precision": 2
   }
+
 ]


### PR DESCRIPTION
Mise à jour des projections pour Wallis, polynésie et Nouvelle Calédonie.

Pour Nouvelle calédonie, je me suis basé sur les données du site géographique: https://georep.nc

Pull request pour le ticket : https://github.com/BaseAdresseNationale/project-legal/issues/153